### PR TITLE
Foolproof comments app, add pagination and sort

### DIFF
--- a/petpal/accounts/urls.py
+++ b/petpal/accounts/urls.py
@@ -1,7 +1,6 @@
 from django.urls import path
 
 from .views import signup_view, LogoutView, account_delete_view
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 app_name = 'accounts'
 

--- a/petpal/accounts/views.py
+++ b/petpal/accounts/views.py
@@ -55,14 +55,14 @@ SUCCESS: status=200, msg="User <user_id> deleted"
 @permission_classes([IsAuthenticated])
 def account_delete_view(request, account_id):
     if account_id != request.user.id:
-        return Response({'msg': 'Forbidden'}, status=status.HTTP_403_FORBIDDEN )
+        return Response({'error': 'Forbidden'}, status=status.HTTP_403_FORBIDDEN )
     
     try:
         user = PetPalUser.objects.get(pk=account_id)
         user.delete()
         return Response({'msg': f'User {account_id} deleted'}, status=status.HTTP_200_OK)
     except PetPalUser.DoesNotExist:
-        return Response({'msg': 'No such user'}, status=status.HTTP_404_NOT_FOUND)
+        return Response({'error': 'No such user'}, status=status.HTTP_404_NOT_FOUND)
 # endregion
 
 # region LOGOUT

--- a/petpal/accounts/views.py
+++ b/petpal/accounts/views.py
@@ -46,7 +46,7 @@ def signup_view(request):
 # region DELETE
 '''
 DELETE account
-ENDPOINT: /api/accounts/<str:account_id>
+ENDPOINT: /api/accounts/<int:account_id>
 METHOD: DELETE
 PERMISSION: Account holder
 SUCCESS: status=200, msg="User <user_id> deleted"

--- a/petpal/applications/views.py
+++ b/petpal/applications/views.py
@@ -24,7 +24,7 @@ def applications_list_and_create_view(request):
 
 '''
 LIST All Applications of a Petlisting
-ENDPOINT: /api/applications/pet/<str:pet_id>
+ENDPOINT: /api/applications/pet/<int:pet_id>
 METHOD: GET
 PERMISSION:
 '''
@@ -35,7 +35,7 @@ def pet_applications_list_view(request, pet_id):
 
 '''
 VIEW / EDIT An Application
-ENDPOINT: /api/applications/<str:app_id>/
+ENDPOINT: /api/applications/<int:app_id>/
 METHOD: GET, PUT
 PERMISSION:
 SUCCESS:

--- a/petpal/comments/models.py
+++ b/petpal/comments/models.py
@@ -17,7 +17,7 @@ class Comment(models.Model):
     seeker = models.ForeignKey(User, on_delete=models.CASCADE, related_name='seeker_comments')
     shelter = models.ForeignKey(User, on_delete=models.CASCADE, related_name='shelter_comments')
     is_review = models.BooleanField() # True: shelter review, False: application comment
-    application = models.ForeignKey(Application, on_delete=models.CASCADE, blank=True)
+    application = models.ForeignKey(Application, on_delete=models.CASCADE, blank=True, null=True)
     notification = GenericRelation(Notification, related_query_name='comments')
 
     def save(self, *args, **kwargs):

--- a/petpal/comments/views.py
+++ b/petpal/comments/views.py
@@ -119,9 +119,10 @@ def comments_all_applications_list_view(request):
         for application in page_obj.object_list:
             
             data[application.pk] = []
-            comments = application.comment_set.all()
+            comments = application.comment_set.all().order_by('-created_time')
         
-            for comment in comments[:2]: # fixed length preview pagination
+            # for comment in comments[:2]: # fixed length preview pagination, use for P3
+            for comment in comments:
                 data[application.pk].append({
                     "id": comment.pk,
                     "content": comment.content,
@@ -160,10 +161,10 @@ def comments_application_list_view(request, app_id):
     try:
         application = Application.objects.get(pk=app_id)
         if request.user != application.seeker and request.user != application.shelter:
-            return Response({'error': 'User not authorized to view this comment'}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({'error': 'User not authorized to view this comment list'}, status=status.HTTP_401_UNAUTHORIZED)
 
         data = []
-        comments = application.comment_set.all()
+        comments = application.comment_set.all().order_by('-created_time')
 
         # pagination
         paginator = Paginator(comments, per_page=2)
@@ -210,7 +211,7 @@ def comments_shelter_list_view(request, shelter_id):
         if shelter.role != 'SHELTER':
             return JsonResponse({'data': 'Shelter does not exist'}, status=status.HTTP_400_BAD_REQUEST)
         
-        comments = Comment.objects.filter(shelter=shelter, is_review=True)
+        comments = Comment.objects.filter(shelter=shelter, is_review=True).order_by('-created_time')
         data = []
 
         # pagination

--- a/petpal/comments/views.py
+++ b/petpal/comments/views.py
@@ -1,14 +1,14 @@
 # from django.shortcuts import render
 from rest_framework.response import Response
 from rest_framework import status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 
+from django.core.paginator import Paginator
 from django.http import JsonResponse
 from applications.models import Application
 from .models import Comment
 from accounts.models import PetPalUser as User
-
-# Create your views here.
 
 '''
 CREATE New Comment
@@ -18,39 +18,51 @@ PERMISSION: User logged in and must be part of the application if is_review == F
 SUCCESS:
 '''
 @api_view(['POST'])
+@permission_classes([IsAuthenticated])
 def comment_create_view(request):
-    if not request.user.is_authenticated:
-        return JsonResponse({'data': 'User not logged in'}, status=status.HTTP_401_UNAUTHORIZED)
-    is_author_seeker = request.data.get('is_author_seeker')
+    is_author_seeker = True if request.user.role == User.Role.SEEKER else False
     is_review = request.data.get('is_review')
     content = request.data.get('content')
-    seeker_email = request.data.get('seeker_email')
-    shelter_email = request.data.get('shelter_email')
+
+    # Check if email is seeker -> shelter, shelter -> seeker
+    if request.user.role == User.objects.get(email=request.data.get('recipient_email')).role:
+        return Response({'error': f'{request.user.role}-{request.user.role} communication not supported'}, status=status.HTTP_400_BAD_REQUEST)
+    
+    if is_author_seeker:
+        seeker_email = request.user.email
+        shelter_email = request.data.get('recipient_email')
+    else:
+        shelter_email = request.user.email
+        seeker_email = request.data.get('recipient_email')
+    
     if is_review == None or is_author_seeker == None or content == None or seeker_email == None or shelter_email == None:
-        return JsonResponse({'data': 'Missing fields'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({'error': 'Missing fields'}, status=status.HTTP_400_BAD_REQUEST)
+    
     if is_review == False:
+        # Application message
         application_id = request.data.get('application_id')
         try:
             application = Application.objects.get(pk=application_id)
             # Check if user is part of the application
             if request.user != application.seeker and request.user != application.petlisting.owner:
-                return JsonResponse({'data': 'User not authorized to comment on this application'}, status=status.HTTP_401_UNAUTHORIZED)
+                return Response({'error': 'User not authorized to comment on this application'}, status=status.HTTP_401_UNAUTHORIZED)
             new_comment = Comment(content=content, is_author_seeker=is_author_seeker, seeker=application.seeker, shelter=application.petlisting.owner, is_review=is_review, application=application)
             new_comment.save()
-            return JsonResponse({'data': 'Comment Created'}, status=status.HTTP_200_OK)
-        except:
-            return JsonResponse({'data': 'Application does not exist'}, status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse({'msg': 'Comment Created'}, status=status.HTTP_200_OK)
+        except Exception as e: 
+            # might also fail at save(), not necessarily "comment doesn't exist"
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
     else:
+        # Shelter comment
         try:
             seeker = User.objects.get(email=seeker_email)
             shelter = User.objects.get(email=shelter_email)
             rating = request.data.get('rating')
             new_comment = Comment(content=content, is_author_seeker=is_author_seeker, seeker=seeker, shelter=shelter, is_review=is_review, rating=rating)
             new_comment.save()
-            return JsonResponse({'data': 'Review Created'}, status=status.HTTP_200_OK)
-        except:
-            return JsonResponse({'data': 'User does not exist'}, status=status.HTTP_400_BAD_REQUEST)
-
+            return Response({'msg': 'Review Created'}, status=status.HTTP_200_OK)
+        except Exception as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
 '''
 VIEW A Comment
@@ -59,14 +71,12 @@ METHOD: GET
 PERMISSION: User logged in and must be the author or recipient of the comment
 '''
 @api_view(['GET'])
+@permission_classes([IsAuthenticated])
 def comment_detail_view(request, msg_id):
-    if not request.user.is_authenticated:
-        return JsonResponse({'data': 'User not logged in'}, status=status.HTTP_401_UNAUTHORIZED)
-    if request.user != comment.seeker and request.user != comment.shelter:
-        return JsonResponse({'data': 'User not authorized to view this comment'}, status=status.HTTP_401_UNAUTHORIZED)
-
     try:
         comment = Comment.objects.get(pk=msg_id)
+        if request.user != comment.seeker and request.user != comment.shelter:
+            return Response({'error': 'User not authorized to view this comment'}, status=status.HTTP_401_UNAUTHORIZED)
         data = {
             "id": comment.pk,
             "content": comment.content,
@@ -78,9 +88,9 @@ def comment_detail_view(request, msg_id):
             "is_review": comment.is_review,
             "application": comment.application.pk,
         }
-        return JsonResponse({'data': data}, status=status.HTTP_200_OK)
+        return Response({'data': data}, status=status.HTTP_200_OK)
     except:
-        return JsonResponse({'data': 'Comment does not exist'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({'error': 'Comment does not exist'}, status=status.HTTP_400_BAD_REQUEST)
 
 '''
 LIST All Comments of a User's All Applications
@@ -92,19 +102,26 @@ Returns in form:
 {application_id: [comments], application_id: [comments], ...}
 '''
 @api_view(['GET'])
+@permission_classes([IsAuthenticated])
 def comments_all_applications_list_view(request):
-    if not request.user.is_authenticated:
-        return JsonResponse({'data': 'User not logged in'}, status=status.HTTP_401_UNAUTHORIZED)
     try:
         if request.user.role == 'SHELTER':
             user_applications = User.objects.get(pk=request.user.pk).shelter_applications.all()
         else:
             user_applications = User.objects.get(pk=request.user.pk).seeker_applications.all()
         data = {}
-        for application in user_applications:
+
+        # Visualization: Message center with a message preview so paginating user_applications not comments
+        paginator = Paginator(user_applications, per_page=1)
+        page_number = request.GET.get("page", 1)
+        page_obj = paginator.get_page(page_number)
+        
+        for application in page_obj.object_list:
+            
             data[application.pk] = []
             comments = application.comment_set.all()
-            for comment in comments:
+        
+            for comment in comments[:2]: # fixed length preview pagination
                 data[application.pk].append({
                     "id": comment.pk,
                     "content": comment.content,
@@ -116,9 +133,19 @@ def comments_all_applications_list_view(request):
                     "is_review": comment.is_review,
                     "application": comment.application.pk,
                 })
-        return JsonResponse({'data': data}, status=status.HTTP_200_OK)
-    except:
-        return JsonResponse({'data': 'Error'}, status=status.HTTP_400_BAD_REQUEST)
+
+        payload = {
+            "page": {
+                "current": page_obj.number,
+                "has_next": page_obj.has_next(),
+                "has_previous": page_obj.has_previous(),
+            },
+            "data": data
+        }
+        
+        return Response(payload, status=status.HTTP_200_OK)
+    except Exception as e:
+        return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
 '''
 LIST All Comments of a Certain Application
@@ -128,14 +155,22 @@ PERMISSION: User logged in and must be part of the application
 FE: Message History with Shelter, Convo Name: Application
 '''
 @api_view(['GET'])
+@permission_classes([IsAuthenticated])
 def comments_application_list_view(request, app_id):
-    if not request.user.is_authenticated:
-        return JsonResponse({'data': 'User not logged in'}, status=status.HTTP_401_UNAUTHORIZED)
     try:
         application = Application.objects.get(pk=app_id)
+        if request.user != application.seeker and request.user != application.shelter:
+            return Response({'error': 'User not authorized to view this comment'}, status=status.HTTP_401_UNAUTHORIZED)
+
         data = []
         comments = application.comment_set.all()
-        for comment in comments:
+
+        # pagination
+        paginator = Paginator(comments, per_page=2)
+        page_number = request.GET.get("page", 1)
+        page_obj = paginator.get_page(page_number)
+
+        for comment in page_obj.object_list:
             data.append({
                 "id": comment.pk,
                 "content": comment.content,
@@ -147,9 +182,19 @@ def comments_application_list_view(request, app_id):
                 "is_review": comment.is_review,
                 "application": comment.application.pk,
             })
-        return JsonResponse({'data': data}, status=status.HTTP_200_OK)
+
+        payload = {
+            "page": {
+                "current": page_obj.number,
+                "has_next": page_obj.has_next(),
+                "has_previous": page_obj.has_previous(),
+            },
+            "data": data
+        }
+        
+        return Response(payload, status=status.HTTP_200_OK)
     except:
-        return JsonResponse({'data': 'Application does not exist'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({'error': 'Application does not exist'}, status=status.HTTP_400_BAD_REQUEST)
 
 '''
 LIST All Comments of a Shelter
@@ -158,16 +203,23 @@ METHOD: GET
 PERMISSION: User logged in
 '''
 @api_view(['GET'])
+@permission_classes([IsAuthenticated])
 def comments_shelter_list_view(request, shelter_id):
-    if not request.user.is_authenticated:
-        return JsonResponse({'data': 'User not logged in'}, status=status.HTTP_401_UNAUTHORIZED)
     try:
         shelter = User.objects.get(pk=shelter_id)
         if shelter.role != 'SHELTER':
             return JsonResponse({'data': 'Shelter does not exist'}, status=status.HTTP_400_BAD_REQUEST)
+        
         comments = Comment.objects.filter(shelter=shelter, is_review=True)
         data = []
-        for comment in comments:
+
+        # pagination
+        paginator = Paginator(comments, per_page=1)
+        page_number = request.GET.get("page", 1)
+        page_obj = paginator.get_page(page_number)
+
+        # for comment in page_obj.object_list:
+        for comment in page_obj:
             data.append({
                 "id": comment.pk,
                 "content": comment.content,
@@ -177,8 +229,18 @@ def comments_shelter_list_view(request, shelter_id):
                 "seeker": comment.seeker.email,
                 "shelter": comment.shelter.email,
                 "is_review": comment.is_review,
-                "application": comment.application.pk,
+                "application": comment.application,
             })
-        return JsonResponse({'data': data}, status=status.HTTP_200_OK)
-    except:
-        return JsonResponse({'data': 'Error'}, status=status.HTTP_400_BAD_REQUEST)
+
+        payload = {
+            "page": {
+                "current": page_obj.number,
+                "has_next": page_obj.has_next(),
+                "has_previous": page_obj.has_previous(),
+            },
+            "data": data
+        }
+
+        return JsonResponse(payload, status=status.HTTP_200_OK)
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/petpal/comments/views.py
+++ b/petpal/comments/views.py
@@ -66,7 +66,7 @@ def comment_create_view(request):
 
 '''
 VIEW A Comment
-ENDPOINT: /api/comments/<str:msg_id>
+ENDPOINT: /api/comments/<int:msg_id>
 METHOD: GET
 PERMISSION: User logged in and must be the author or recipient of the comment
 '''
@@ -150,7 +150,7 @@ def comments_all_applications_list_view(request):
 
 '''
 LIST All Comments of a Certain Application
-ENDPOINT: /api/comments/applications/<str:app_id>
+ENDPOINT: /api/comments/applications/<int:app_id>
 METHOD: GET
 PERMISSION: User logged in and must be part of the application
 FE: Message History with Shelter, Convo Name: Application
@@ -199,7 +199,7 @@ def comments_application_list_view(request, app_id):
 
 '''
 LIST All Comments of a Shelter
-ENDPOINT: /api/comments/shelter/<str:shelter_id>
+ENDPOINT: /api/comments/shelter/<int:shelter_id>
 METHOD: GET
 PERMISSION: User logged in
 '''

--- a/petpal/notifications/views.py
+++ b/petpal/notifications/views.py
@@ -32,7 +32,7 @@ def notifications_list_view(request):
 
 '''
 VIEW / DELETE A Notification
-ENDPOINT: /api/notifications/<str:note_id>/
+ENDPOINT: /api/notifications/<int:note_id>/
 METHOD: GET, DELETE
 PERMISSION: User logged in and must be the recipient of the notification
 SUCCESS:

--- a/petpal/petlistings/views.py
+++ b/petpal/petlistings/views.py
@@ -35,7 +35,7 @@ def petlistings_category_list_view(request, category):
 
 '''
 VIEW / EDIT / DELETE A petlisting
-ENDPOINT: /api/petlistings/<str:pet_id>/
+ENDPOINT: /api/petlistings/<int:pet_id>/
 METHOD: GET, PUT, DELETE
 PERMISSION:
 SUCCESS:

--- a/petpal/script.py
+++ b/petpal/script.py
@@ -39,7 +39,10 @@ def create_initial_data_json():
     app1 = Application.objects.create(first_name="John", last_name="Doe", address="123 Main St", phone="123-456-7890",
                                       email="seeker1@example.com", contact_pref="E", pet_number=1, has_children=False,
                                       experience="EX", residence_type="C", status="P", seeker=seeker1, shelter=shelter1, petlisting=petlisting1)
-    app2 = Application.objects.create(first_name="Jane", last_name="Doe", address="123 Main St", phone="123-456-7890",
+    app2 = Application.objects.create(first_name="John", last_name="Doe", address="123 Main St", phone="123-456-7890",
+                                      email="seeker1@example.com", contact_pref="E", pet_number=1, has_children=False,
+                                      experience="EX", residence_type="C", status="P", seeker=seeker1, shelter=shelter2, petlisting=petlisting2)
+    app3 = Application.objects.create(first_name="Jane", last_name="Doe", address="123 Main St", phone="123-456-7890",
                                       email="seeker2@example.com", contact_pref="E", pet_number=2, has_children=False,
                                       experience="EX", residence_type="C", status="P", seeker=seeker2, shelter=shelter2, petlisting=petlisting2)
     
@@ -48,6 +51,11 @@ def create_initial_data_json():
     comment1 = Comment.objects.create(content="I would love to see Buddy in person!", is_author_seeker=True, seeker=seeker1, shelter=shelter1, is_review=False, application=app1)
     comment2 = Comment.objects.create(content="Sure!, what time are you avaliable to visit our shelter?", is_author_seeker=False, seeker=seeker1, shelter=shelter1, is_review=False, application=app1)
     comment3 = Comment.objects.create(content="Are you guys open on weekends?", is_author_seeker=True, seeker=seeker1, shelter=shelter1, is_review=False, application=app1)
+    comment4 = Comment.objects.create(content="Hi! May I get an update on my application?", is_author_seeker=True, seeker=seeker1, shelter=shelter2, is_review=False, application=app2)
+    review1 = Comment.objects.create(content="Awesome!", is_author_seeker=True, seeker=seeker1, shelter=shelter1, is_review=True, rating=5)
+    review2 = Comment.objects.create(content="I would definitely visit again", is_author_seeker=True, seeker=seeker2, shelter=shelter2, is_review=True, rating=5)
+    review3 = Comment.objects.create(content="Very long response time to messages", is_author_seeker=True, seeker=seeker1, shelter=shelter3, is_review=True, rating=3)
+    review4 = Comment.objects.create(content="We're very sorry for your inconvenience, we will try to improve next time.", is_author_seeker=False, seeker=seeker1, shelter=shelter3, is_review=True)
     
     # Notifications should be created automatically when comments, petlistings, and applications are created
     

--- a/petpal/seekers/views.py
+++ b/petpal/seekers/views.py
@@ -19,7 +19,7 @@ def seekers_list_view(request):
 
 '''
 VIEW / EDIT / DELETE A Seeker
-ENDPOINT: /api/seekers/<str:account_id>/
+ENDPOINT: /api/seekers/<int:account_id>/
 METHOD: GET, PUT, DELETE
 PERMISSION:
 SUCCESS:

--- a/petpal/shelters/views.py
+++ b/petpal/shelters/views.py
@@ -19,7 +19,7 @@ def shelters_list_view(request):
 
 '''
 VIEW / EDIT / DELETE A shelter
-ENDPOINT: /api/shelters/<str:account_id>/
+ENDPOINT: /api/shelters/<int:account_id>/
 METHOD: GET, PUT, DELETE
 PERMISSION:
 SUCCESS:


### PR DESCRIPTION
Fix all the bugs that were mentioned in #5, and modify all return
objects to match given convention.
    
Rapid tested on postman and added more gatekeeping statements for
invalid data/unauthorized actions.

Add pagination support for all list views. Currently all pagination are
set to a low value for demo simplicty, need to increase limit in P3 to
have a visually pleasing website.

Add more test data to test different action combinations

Also established a convention for return Response:
SUCCESS:
        if returning data, `return Response({"data": data}, status=200)`
        if returning message, `return Response({"msg": msg}, status=200)`
FAIL:
        `return Response({"error": error_msg}, status)`