### PR TITLE
Yanbo/profile

### DIFF
--- a/backend/comments/views.py
+++ b/backend/comments/views.py
@@ -85,7 +85,6 @@ def comment_create_view(request):
             seeker = User.objects.get(email=seeker_email)
             shelter = User.objects.get(email=shelter_email)
             rating = request.data.get('rating', None)
-            print(rating)
             if (rating == None or int(rating) < 1 or int(rating) > 5):
                 if (request.user.role == User.Role.SEEKER):
                     # Seeker rating shelter, shelter reply can have no rating

--- a/backend/petlistings/urls.py
+++ b/backend/petlistings/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 
-from .views import petlistings_list_and_create_view, petlisting_detail_view, petlisting_photo_view
+from .views import petlistings_list_and_create_view, petlisting_detail_view, petlisting_photo_view, shelter_petlistings_list_view
 
 app_name = 'petlistings'
 
 urlpatterns = [
     path('', petlistings_list_and_create_view, name='petlisting-lists'),
     path('/<int:pet_id>', petlisting_detail_view, name='pelisting-detail'),
-    path('/<int:pet_id>/<int:photo_id>', petlisting_photo_view, name='petlisting-photo')
+    path('/<int:pet_id>/<int:photo_id>', petlisting_photo_view, name='petlisting-photo'),
+    path('/shelter/<str:shelter_email>', shelter_petlistings_list_view, name='shelter-petlistings-list')
 ]

--- a/backend/petlistings/views.py
+++ b/backend/petlistings/views.py
@@ -11,6 +11,52 @@ from accounts.models import PetPalUser as User
 from .serializers import PetListingSerializer
 
 # Create your views here.
+'''
+LIST All Petlistings from a Shelter
+ENDPOINT: /api/petlistings/shelter/<str:shelter_email>/
+METHOD: Get
+PERMISSION: User logged in
+SUCCESS:
+'''
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def shelter_petlistings_list_view(request, shelter_email):
+    paginator = PageNumberPagination()
+    paginator.page_size = 6
+    
+    try:
+        all_petlistings = PetListing.objects.filter(owner=User.objects.get(email=shelter_email))
+        paginated_petlistings = paginator.paginate_queryset(all_petlistings, request)
+        data = []
+        for listing in paginated_petlistings:
+            result = {
+                'id': listing.pk,
+                'name': listing.name,
+                'category': listing.category,
+                'breed': listing.breed,
+                'age': listing.age,
+                'gender': listing.gender,
+                'size': listing.size,
+                'status': listing.status,
+                'created_time': listing.created_time,
+                'med_history': listing.med_history,
+                'behaviour': listing.behaviour,
+                'special_needs': listing.special_needs,
+                'description': listing.description,
+                'owner': listing.owner.email,
+            }
+            result['photos'] = []
+            for image in listing.images.all():
+                result['photos'].append({
+                    'id': image.pk,
+                    'url': image.image.url
+                })
+            data.append(result)
+        return paginator.get_paginated_response({'data': data})
+    except:
+        return Response({'error': 'Shelter does not exist'}, status=status.HTTP_400_BAD_REQUEST)
+    
+
 
 '''
 LIST All Petlistings with or without filter / CREATE New Petlisting
@@ -54,7 +100,7 @@ def petlistings_list_and_create_view(request):
                 
         data = []
         paginator = PageNumberPagination()
-        paginator.page_size = 2
+        paginator.page_size = 6
         
         petlistings = PetListing.objects.filter(**filter)
         paginated_petlistings = paginator.paginate_queryset(petlistings, request)

--- a/backend/shelters/views.py
+++ b/backend/shelters/views.py
@@ -87,7 +87,20 @@ def shelter_detail_view(request, account_id):
     if request.method == 'GET':
         # Give details of the shelter
         serializer = ShelterSerializer(shelter, many=False)
-        return Response({'msg': 'Shelter Detail', 'data': serializer.data}, status=status.HTTP_200_OK)
+        # Calculate the average rating out of 5
+        avg_rating = 0
+        count = 0
+        for review in shelter.shelter_comments.all():
+            if (review.is_review and review.rating):
+                avg_rating += review.rating
+                count += 1
+        if count != 0:
+            avg_rating = avg_rating / count
+        else:
+            avg_rating = None
+        data = serializer.data
+        data['avg_rating'] = avg_rating
+        return Response({'msg': 'Shelter Detail', 'data': data}, status=status.HTTP_200_OK)
 
     if request.method == 'PUT':
         # Check that the request is from the shelter themselves

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+node_modules
 /.pnp
 .pnp.js
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,9 @@
         "react-router-dom": "^6.20.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "tailwindcss": "^3.3.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,5 +43,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.3.5"
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,7 @@ import ShelterEdit from './pages/shelters/ShelterEdit';
 
 import Profile from './pages/profile/Profile';
 import ProfileEdit from './pages/profile/ProfileEdit';
+import ProfileOther from './pages/profile/ProfileOther';
 
 import PetListings from './pages/petlistings/PetListings';
 import PetDetail from './pages/petlistings/PetDetail';
@@ -47,6 +48,7 @@ function App() {
 
             <Route path='profile' element={<Profile />} />
             <Route path='profile/edit' element={<ProfileEdit />} />
+            <Route path='profile/:userId' element={<ProfileOther />} />
             
             <Route path='petlistings' element={<PetListings />} />
             <Route path='petlistings/:petId' element={<PetDetail />} />

--- a/frontend/src/pages/profile/Profile.css
+++ b/frontend/src/pages/profile/Profile.css
@@ -1,0 +1,150 @@
+main {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+
+.profile-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: 
+        'profile-img profile-desc'
+        'profile-favs profile-favs';
+    width: 100%;
+}
+
+.shelter-profile-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: 
+        'profile-img profile-desc'
+        'profile-pets profile-pets';
+    width: 100%;
+    flex-grow: 1;
+}
+
+.profile-img {
+    grid-area: profile-img;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    justify-content: center;
+    align-items: center;
+}
+
+.profile-container {
+    height: 250px;
+    width: 250px;
+    border-radius: 50%;
+    overflow: hidden;
+}
+
+.shelter-profile-container {
+    height: 250px;
+    width: 250px;
+    border-radius: 10%;
+    overflow: hidden;
+}
+
+.profile-desc {
+    grid-area: profile-desc;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: start;
+    margin: 4rem;
+}
+
+.profile-list {
+    width: 100%;
+}
+
+.profile-list li {
+    margin-bottom: 1rem;
+    width: 60%;
+}
+
+.profile-list li:last-child {
+    margin-bottom: 0;
+}
+
+.profile-favs {
+    grid-area: profile-favs;
+}
+
+.profile-pets {
+    grid-area: profile-pets;
+}
+
+.line {
+    border: none;
+    width: 50%;
+    height: 2px; 
+    background-color: #000;
+    margin: 20px 0;
+}
+
+.review-box {
+    width: 60%;
+}
+
+@media (max-width: 36rem) { 
+    /* size for phone is basically the same */
+    .profile-grid {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        margin-top: 4rem;
+        flex-grow: 1;
+    }
+
+    .profile-desc {
+        grid-area: profile-desc;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        margin: 0rem;
+        margin-top : 4rem;
+        margin-bottom: 4rem;
+    }
+
+    .profile-list {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .line {
+        border: none;
+        width: 50%;
+        height: 2px; 
+        background-color: #000;
+        margin: 20px 0;
+    }
+
+    .shelter-profile-grid {
+        display: flex;
+        flex-direction: column;
+        margin-top: 4rem;
+        width: 100%;
+        flex-grow: 1;
+    }
+
+    .review-box {
+        width: 90%;
+    }
+}
+
+#add-pet {
+    background-color: gray;
+    border-radius: 20%;
+}
+
+.shelter-pet-list {
+    display: flex;
+    align-items: center;
+}

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -9,6 +9,7 @@ function Profile() {
   const [user, setUser] = useState(null)
   const [shelterPets, setShelterPets] = useState(null)
   const [favPets, setFavPets] = useState(null)
+  const [reviews, setReviews] = useState(null)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -27,20 +28,51 @@ function Profile() {
     const fetchUserData = async () => {
       try {
         if (role === 'shelter') {
-          const data = await getShelterPets();
-          setShelterPets(data);
+          const data = await getShelterPets()
+          setShelterPets(data)
+          const reviews = await getReviews()
+          setReviews(reviews)
         } else if (role === 'seeker') {
-          const data = await getFavPets();
-          setFavPets(data);
+          const data = await getFavPets()
+          setFavPets(data)
         }
       } catch (error) {
-        console.error(error);
+        console.error(error)
+      }
+    }
+
+    const getReviews = async () => {
+      let nextPage = `${process.env.REACT_APP_API_URL}/api/comments/shelter/${userId}`
+      const allResults = []
+      var pageNum = 1
+      try {
+        while (nextPage) {
+          const response = await fetch(nextPage, {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          })
+
+          const data = await response.json()
+          allResults.push(...data.data)
+          if (data.page.has_next) {
+            nextPage = `${process.env.REACT_APP_API_URL}/api/comments/shelter/${userId}?page=${pageNum + 1}`
+            pageNum += 1
+          } else {
+            break
+          }
+        }
+        console.log(allResults)
+        return allResults
+      } catch (error) {
+        console.error(error)
       }
     }
 
     const getShelterPets = async () => {
-      let nextPage = `${process.env.REACT_APP_API_URL}/api/petlistings/shelter/${user?.data.email}`;
-      const allResults = [];
+      var nextPage = `${process.env.REACT_APP_API_URL}/api/petlistings/shelter/${user?.data.email}`
+      const allResults = []
     
       try {
         while (nextPage) {
@@ -49,22 +81,22 @@ function Profile() {
             headers: {
               Authorization: `Bearer ${token}`
             }
-          });
+          })
     
-          const data = await response.json();
-          allResults.push(...data.results.data);
-          nextPage = data.next;
+          const data = await response.json()
+          allResults.push(...data.results.data)
+          nextPage = data.next
         }
-        return allResults;
+        return allResults
       } catch (error) {
-        console.error(error);
+        console.error(error)
       }
     }
 
     const getFavPets = async () => {
-      let nextPage = `${process.env.REACT_APP_API_URL}/api/seekers/${userId}/favorites`;
-      const allResults = [];
-      var pageNum = 1;
+      let nextPage = `${process.env.REACT_APP_API_URL}/api/seekers/${userId}/favorites`
+      const allResults = []
+      var pageNum = 1
       try {
         while (nextPage) {
           const response = await fetch(nextPage, {
@@ -72,94 +104,119 @@ function Profile() {
             headers: {
               Authorization: `Bearer ${token}`
             }
-          });
+          })
 
-          const data = await response.json();
-          allResults.push(...data.data);
+          const data = await response.json()
+          allResults.push(...data.data)
           if (data.page.has_next) {
-            nextPage = `${process.env.REACT_APP_API_URL}/api/seekers/${userId}/favorites?page=${pageNum + 1}`;
-            pageNum += 1;
+            nextPage = `${process.env.REACT_APP_API_URL}/api/seekers/${userId}/favorites?page=${pageNum + 1}`
+            pageNum += 1
           } else {
-            break;
+            break
           }
         }
-        return allResults;
+        return allResults
       } catch (error) {
-        console.error(error);
+        console.error(error)
       }
     }
 
-    fetchUserData();
+    fetchUserData()
   }, [token, userId, role, navigate, user?.data.email])
 
+  const handleReply = (is_author_seeker, seeker, shelter, e) => {
+    // Get the input field's content
+    const reviewBox = e.target.closest('.review-box')
+    const input = reviewBox.querySelector('input')
+    const content = input.value
+    console.log(content)
+    console.log(is_author_seeker, seeker, shelter)
+
+    fetch(`${process.env.REACT_APP_API_URL}/api/comments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        is_review: true,
+        content: content,
+        recipient_email: is_author_seeker ? seeker : shelter,
+        rating: null,
+        application_id: null,
+      })
+    }).then(res => res.json())
+      .then(data => window.location.reload())
+      .catch(err => console.log(err))
+  }
 
 
   const renderProfile = () => {
     if (role === 'seeker') {
       return (
-        <div class="profile-grid">
-          <div class="profile-img">
-              <div class="profile-container">
-                <img class="rounded-full w-full h-full" src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : "../../../images/logo_ref.png"} alt="../../../images/logo_ref.png" />
+        <div class='profile-grid'>
+          <div class='profile-img'>
+              <div class='profile-container'>
+                <img class='rounded-full w-full h-full' src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : '../../../images/logo_ref.png'} alt='../../../images/logo_ref.png' />
               </div>
-              <a href="profile/edit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full">Edit Profile</a>
+              <a href='profile/edit' class='bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full'>Edit Profile</a>
           </div>
-          <div class="profile-desc">
-            <p class="font-semibold text-5xl break-all">Your Profile</p>
-            <hr class="line"></hr>
-            <ul class="profile-list">
+          <div class='profile-desc'>
+            <p class='font-semibold text-5xl break-all'>Your Profile</p>
+            <hr class='line'></hr>
+            <ul class='profile-list'>
               <li>
-                <span class="font-bold">Email:</span>
-                <span class="text-gray-700">
-                  <a href="mailto: {user?.data.email}">{user?.data.email}</a>
+                <span class='font-bold'>Email:</span>
+                <span class='text-gray-700'>
+                  <a href={`mailto:${user?.data.email}`}>{user?.data.email}</a>
                 </span>
               </li>
               <li>
-                <span class="font-bold">Adress:</span>
-                <span class="text-gray-700">
+                <span class='font-bold'>Adress:</span>
+                <span class='text-gray-700'>
                   <p>{user?.data.address === '' ? 'N/A' : user?.data.address}</p>
                 </span>
               </li>
               <li>
-                <span class="font-bold">Postal Code:</span>
-                <span class="text-gray-700">
+                <span class='font-bold'>Postal Code:</span>
+                <span class='text-gray-700'>
                   <p>{user?.data.postal_code === '' ? 'N/A' : user?.data.postal_code}</p>
                 </span>
               </li>
               <li>
-                <span class="font-bold">City:</span>
-                <span class="text-gray-700">
+                <span class='font-bold'>City:</span>
+                <span class='text-gray-700'>
                   <p>{user?.data.city === '' ? 'N/A' : user?.data.city}</p>
                 </span>
               </li>
               <li>
-                <span class="font-bold">Province:</span>
-                <span class="text-gray-700">
+                <span class='font-bold'>Province:</span>
+                <span class='text-gray-700'>
                   <p>{user?.data.province === '' ? 'N/A' : user?.data.province}</p>
                 </span>
               </li>
               <li>
-                <span class="font-bold">Phone:</span>
-                <span class="text-gray-700">
+                <span class='font-bold'>Phone:</span>
+                <span class='text-gray-700'>
                   <p>{user?.data.phone === '' ? 'N/A' : user?.data.phone}</p>
                 </span>
               </li>
               <li>
-                <a class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full" href="applications">My Applications</a>
+                <a class='bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full' href='applications'>My Applications</a>
               </li>
             </ul>
           </div>
-          <div class="profile-favs">
-            <div className="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
-              <p className="text-xl font-bold">Your Favorites</p>
-              <div className="-m-1 flex flex-wrap md:-m-2">
+          <div class='profile-favs'>
+            <div className='container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4'>
+              <p className='text-xl font-bold'>Your Favorites</p>
+              <div className='-m-1 flex flex-wrap md:-m-2'>
                 {favPets?.map((pet) => (
-                  <div className="flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2">
-                    <a href={`/petlistings/${pet.id}`} className="w-full block">
+                  <div className='flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2'>
+                    <a href={`/petlistings/${pet.id}`} className='w-full block'>
                       <img
                         alt={pet.name}
-                        className="block w-full h-64 object-cover object-center rounded-lg"
-                        src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : "../../../images/logo_ref.png"}
+                        className='block w-full h-64 object-cover object-center rounded-lg'
+                        src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : '../../../images/logo_ref.png'}
                       />
                     </a>
                   </div>
@@ -171,86 +228,144 @@ function Profile() {
       )
     } else {
       return (
-        <div class="profile-grid">
-          <div class="profile-img">
-              <div class="profile-container">
-                <img class="rounded-full w-full h-full" src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : "../../../images/logo_ref.png"} alt="../../../images/logo_ref.png" />
-              </div>
-              <a href="profile/edit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full">Edit Profile</a>
-          </div>
-          <div class="profile-desc">
-            <p class="font-semibold text-5xl break-all">Your Profile</p>
-            <hr class="line"></hr>
-            <ul class="profile-list">
-              <li>
-                <span class="font-bold">Email:</span>
-                <span class="text-gray-700">
-                  <a href="mailto: {user?.data.email}">{user?.data.email}</a>
-                </span>
-              </li>
-              <li>
-                <span class="font-bold">Adress:</span>
-                <span class="text-gray-700">
-                  <p>{user?.data.address === '' ? 'N/A' : user?.data.address}</p>
-                </span>
-              </li>
-              <li>
-                <span class="font-bold">Postal Code:</span>
-                <span class="text-gray-700">
-                  <p>{user?.data.postal_code === '' ? 'N/A' : user?.data.postal_code}</p>
-                </span>
-              </li>
-              <li>
-                <span class="font-bold">City:</span>
-                <span class="text-gray-700">
-                  <p>{user?.data.city === '' ? 'N/A' : user?.data.city}</p>
-                </span>
-              </li>
-              <li>
-                <span class="font-bold">Province:</span>
-                <span class="text-gray-700">
-                  <p>{user?.data.province === '' ? 'N/A' : user?.data.province}</p>
-                </span>
-              </li>
-              <li>
-                <span class="font-bold">Phone:</span>
-                <span class="text-gray-700">
-                  <p>{user?.data.phone === '' ? 'N/A' : user?.data.phone}</p>
-                </span>
-              </li>
-              <li>
-                <span class="font-bold">Mission Statement:</span>
-                <span class="text-gray-700">
-                  <p>{user?.data.description === '' ? 'N/A' : user?.data.description}</p>
-                </span>
-              </li>
-            </ul>
-          </div>
-          <div class="profile-favs">
-            <div class="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
-              <div class="shelter-pet-list">
-                <p class="text-xl font-bold center-text mr-4">Listed Pets</p>
-                  <a href="petlistings/create">
-                    <button class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-1 px-4 rounded-full">
-                      +
-                    </button>
-                  </a>
-              </div>
-              <div className="-m-1 flex flex-wrap md:-m-2">
-                {shelterPets?.map((pet) => (
-                  <div className="flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2 flex flex-col items-center">
-                    <a href={`/petlistings/${pet.id}/edit`} className="w-full block">
-                      <img
-                        alt={pet.name}
-                        className="block w-full h-64 rounded-lg object-cover object-center"
-                        src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : "../../../images/logo_ref.png"}
-                      />
-                    </a>
-                    <p className="text-center">{pet.name}</p>
+        <div>
+          <div class='profile-grid'>
+            <div class='profile-img'>
+                <div class='profile-container'>
+                  <img class='rounded-full w-full h-full' src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : '../../../images/logo_ref.png'} alt='../../../images/logo_ref.png' />
+                </div>
+                <a href='profile/edit' class='bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full'>Edit Profile</a>
+            </div>
+            <div class='profile-desc'>
+              <p class='font-semibold text-5xl break-all'>Your Profile</p>
+              <div class="flex items-center">
+                {user?.data.avg_rating === 0 ? (
+                  <span>No Rating</span>
+                ) : (
+                  <div class="flex items-center">
+                    {Array.from({ length: user?.data.avg_rating }, (_, index) => (
+                      <svg
+                        key={index}
+                        class="w-4 h-4 text-yellow-300 me-1"
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="currentColor"
+                        viewBox="0 0 22 20"
+                      >
+                        <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
+                      </svg>
+                    ))}
+                    {user?.data.avg_rating} out of 5
                   </div>
-                ))}
+                )}
+              </div>
+              <hr class='line'></hr>
+              <ul class='profile-list'>
+                <li>
+                  <span class='font-bold'>Email:</span>
+                  <span class='text-gray-700'>
+                    <a href={`mailto:${user?.data.email}`}>{user?.data.email}</a>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Adress:</span>
+                  <span class='text-gray-700'>
+                    <p>{user?.data.address === '' ? 'N/A' : user?.data.address}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Postal Code:</span>
+                  <span class='text-gray-700'>
+                    <p>{user?.data.postal_code === '' ? 'N/A' : user?.data.postal_code}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>City:</span>
+                  <span class='text-gray-700'>
+                    <p>{user?.data.city === '' ? 'N/A' : user?.data.city}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Province:</span>
+                  <span class='text-gray-700'>
+                    <p>{user?.data.province === '' ? 'N/A' : user?.data.province}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Phone:</span>
+                  <span class='text-gray-700'>
+                    <p>{user?.data.phone === '' ? 'N/A' : user?.data.phone}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Mission Statement:</span>
+                  <span class='text-gray-700'>
+                    <p>{user?.data.description === '' ? 'N/A' : user?.data.description}</p>
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div class='profile-favs'>
+              <div class='container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4'>
+                <div class='shelter-pet-list'>
+                  <p class='text-xl font-bold center-text mr-4'>Listed Pets</p>
+                    <a href='petlistings/create'>
+                      <button class='bg-gray-500 hover:bg-gray-700 text-white font-bold py-1 px-4 rounded-full'>
+                        +
+                      </button>
+                    </a>
+                </div>
+                <div className='-m-1 flex flex-wrap md:-m-2'>
+                  {shelterPets?.map((pet) => (
+                    <div className='flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2 flex flex-col items-center'>
+                      <a href={`/petlistings/${pet.id}/edit`} className='w-full block'>
+                        <img
+                          alt={pet.name}
+                          className='block w-full h-64 rounded-lg object-cover object-center'
+                          src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : '../../../images/logo_ref.png'}
+                        />
+                      </a>
+                      <p className='text-center'>{pet.name}</p>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
+          </div>
+          <div class="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
+            <p class="text-xl font-bold center-text mr-4">My Reviews</p>
+            {reviews?.map((review) => (
+              <div class="review-box mx-auto flex items-center flex-col rounded-lg bg-white p-6 shadow-[0_2px_15px_-3px_rgba(0,0,0,0.07),0_10px_20px_-2px_rgba(0,0,0,0.04)] dark:bg-neutral-700">
+                <div class="flex items-center">
+                  {Array.from({ length: review.rating }, (_, index) => (
+                    <svg
+                      key={index}
+                      class="w-4 h-4 text-yellow-300 me-1"
+                      aria-hidden="true"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="currentColor"
+                      viewBox="0 0 22 20"
+                    >
+                      <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
+                    </svg>
+                  ))}
+                  <p class="ml-2">{review.rating} out of 5</p>
+                </div>
+                <div class="mt-2">{review.content}</div>
+                {review?.reply ? (
+                  <p>Your response: {review?.reply.content}</p>
+                ) : (
+                  <div>
+                  <input type="text" class="mt-2 border-2 border-gray-300 rounded-md p-2 w-full" placeholder="Reply to review" />
+                  <button class="mt-2 bg-gray-500 hover:bg-gray-700 text-white font-bold py-1 px-4 rounded-full"
+                    onClick={(e) => handleReply(review.is_author_seeker, review.seeker, review.shelter, e)}
+                  >
+                    Reply
+                  </button>
+                </div>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       )
@@ -258,7 +373,7 @@ function Profile() {
   }
 
   return (
-    <div class="w-full h-full">
+    <div class='w-full h-full'>
       {user && renderProfile()}
     </div>
 

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -14,7 +14,6 @@ function Profile() {
 
   useEffect(() => {
     if (!token) return navigate('/login')
-    console.log(userId)
     // Fetch user data
     fetch(`${process.env.REACT_APP_API_URL}/api/${role}s/${userId}`, {
       method: 'GET',
@@ -37,7 +36,6 @@ function Profile() {
           const data = await getShelterPets()
           setShelterPets(data)
           const reviews = await getReviews()
-          console.log(reviews)
           setReviews(reviews)
         } else if (role === 'seeker') {
           const data = await getFavPets()
@@ -70,7 +68,6 @@ function Profile() {
             break
           }
         }
-        console.log(allResults)
         return allResults
       } catch (error) {
         console.error(error)
@@ -136,8 +133,6 @@ function Profile() {
     const reviewBox = e.target.closest('.review-box')
     const input = reviewBox.querySelector('input')
     const content = input.value
-    console.log(content)
-    console.log(is_author_seeker, seeker, shelter)
 
     fetch(`${process.env.REACT_APP_API_URL}/api/comments`, {
       method: 'POST',
@@ -356,11 +351,11 @@ function Profile() {
                       <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
                     </svg>
                   ))}
-                  <p class="ml-2">{review.rating.toFixed(2)} out of 5</p>
+                  <p class="ml-2 text-white">{review.rating.toFixed(2)} out of 5</p>
                 </div>
-                <div class="mt-2">{review.seeker}: {review.content}</div>
+                <div class="mt-2 text-white">{review.seeker}: {review.content}</div>
                 {review?.reply ? (
-                  <p>Your response: {review?.reply.content}</p>
+                  <p class="mt-2 text-white">Your response: {review?.reply.content}</p>
                 ) : (
                   <div>
                   <input type="text" class="mt-2 border-2 border-gray-300 rounded-md p-2 w-full" placeholder="Reply to review" />

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -2,106 +2,267 @@ import React, { useEffect, useState } from 'react'
 import { useAuth } from '../../context/AuthContext'
 import './Profile.css'
 import '../../styles/tailwind.css'
+import { useNavigate } from 'react-router-dom'
 
 function Profile() {
   const { token, userId, role } = useAuth()
   const [user, setUser] = useState(null)
+  const [shelterPets, setShelterPets] = useState(null)
+  const [favPets, setFavPets] = useState(null)
+  const navigate = useNavigate()
 
   useEffect(() => {
+    if (!token) return navigate('/login')
     // Fetch user data
-    if (role === 'seeker') {
-      fetch(`${process.env.REACT_APP_API_URL}/api/seekers/${userId}`, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`
+    fetch(`${process.env.REACT_APP_API_URL}/api/${role}s/${userId}`, { // TODO: Change to /api/seekers/${userId
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }).then(res => res.json())
+      .then(data => setUser(data))
+      .catch(err => console.log(err))
+    
+    // Different fetches for different roles
+    const fetchUserData = async () => {
+      try {
+        if (role === 'shelter') {
+          const data = await getShelterPets();
+          setShelterPets(data);
+        } else if (role === 'seeker') {
+          const data = await getFavPets();
+          setFavPets(data);
         }
-      }).then(res => res.json())
-        .then(data => setUser(data))
-        .catch(err => console.log(err))
-    } else {
-      fetch(`${process.env.REACT_APP_API_URL}/api/shelters/${userId}`, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      }).then(res => res.json())
-        .then(data => setUser(data))
-        .catch(err => console.log(err))
+      } catch (error) {
+        console.error(error);
+      }
     }
-  }, [token, userId, role])
 
-  return (
-    <div class="profile-grid">
-      <div class="profile-img">
-          <div class="profile-container">
-            <img class="rounded-full w-full h-full" src={`${process.env.REACT_APP_API_URL}${user?.user_data.avatar}`} alt="profile" />
-          </div>
-          <a href="profile/edit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full">Edit Profile</a>
-      </div>
-      <div class="profile-desc">
-        <p class="font-semibold text-5xl break-all">Your Profile</p>
-        <hr class="line"></hr>
-        <ul class="profile-list">
-          <li>
-            <span class="font-bold">Email:</span>
-            <span class="text-gray-700">
-              <a href="mailto: {user?.user_data.email}">{user?.user_data.email}</a>
-            </span>
-          </li>
-          <li>
-            <span class="font-bold">Adress:</span>
-            <span class="text-gray-700">
-              <p>{user?.user_data.address === '' ? 'N/A' : user?.user_data.address}</p>
-            </span>
-          </li>
-          <li>
-            <span class="font-bold">Postal Code:</span>
-            <span class="text-gray-700">
-              <p>{user?.user_data.postal_code === '' ? 'N/A' : user?.user_data.postal_code}</p>
-            </span>
-          </li>
-          <li>
-            <span class="font-bold">City:</span>
-            <span class="text-gray-700">
-              <p>{user?.user_data.city === '' ? 'N/A' : user?.user_data.city}</p>
-            </span>
-          </li>
-          <li>
-            <span class="font-bold">Province:</span>
-            <span class="text-gray-700">
-              <p>{user?.user_data.province === '' ? 'N/A' : user?.user_data.province}</p>
-            </span>
-          </li>
-          <li>
-            <span class="font-bold">Phone:</span>
-            <span class="text-gray-700">
-              <p>{user?.user_data.phone === '' ? 'N/A' : user?.user_data.phone}</p>
-            </span>
-          </li>
-          <li>
-            <a class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full" href="applications">My Applications</a>
-          </li>
-        </ul>
-      </div>
-      <div class="profile-favs">
-        <div class="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
-          <p class="text-xl font-bold">Your Favorites</p>
-          <div class="-m-1 flex flex-wrap md:-m-2">
-            {user?.fav_pets.map((pet) => (
-              <div class="flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2 flex justify-center items-center">
-                <a href={`/petlistings/${pet.id}`}>
-                  <img
-                  alt="gallery"
-                  class="block h-64 w-full rounded-lg object-cover object-center"
-                  src="TODO: Add image here"
-                  />
-                </a>
+    const getShelterPets = async () => {
+      let nextPage = `${process.env.REACT_APP_API_URL}/api/petlistings/shelter/${user?.data.email}`;
+      const allResults = [];
+    
+      try {
+        while (nextPage) {
+          const response = await fetch(nextPage, {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          });
+    
+          const data = await response.json();
+          allResults.push(...data.results.data);
+          nextPage = data.next;
+        }
+        return allResults;
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    const getFavPets = async () => {
+      let nextPage = `${process.env.REACT_APP_API_URL}/api/seekers/${userId}/favorites`;
+      const allResults = [];
+      var pageNum = 1;
+      try {
+        while (nextPage) {
+          const response = await fetch(nextPage, {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          });
+
+          const data = await response.json();
+          allResults.push(...data.data);
+          if (data.page.has_next) {
+            nextPage = `${process.env.REACT_APP_API_URL}/api/seekers/${userId}/favorites?page=${pageNum + 1}`;
+            pageNum += 1;
+          } else {
+            break;
+          }
+        }
+        return allResults;
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    fetchUserData();
+  }, [token, userId, role, navigate, user?.data.email])
+
+
+
+  const renderProfile = () => {
+    if (role === 'seeker') {
+      return (
+        <div class="profile-grid">
+          <div class="profile-img">
+              <div class="profile-container">
+                <img class="rounded-full w-full h-full" src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : "../../../images/logo_ref.png"} alt="../../../images/logo_ref.png" />
               </div>
-            ))}
+              <a href="profile/edit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full">Edit Profile</a>
+          </div>
+          <div class="profile-desc">
+            <p class="font-semibold text-5xl break-all">Your Profile</p>
+            <hr class="line"></hr>
+            <ul class="profile-list">
+              <li>
+                <span class="font-bold">Email:</span>
+                <span class="text-gray-700">
+                  <a href="mailto: {user?.data.email}">{user?.data.email}</a>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Adress:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.address === '' ? 'N/A' : user?.data.address}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Postal Code:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.postal_code === '' ? 'N/A' : user?.data.postal_code}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">City:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.city === '' ? 'N/A' : user?.data.city}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Province:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.province === '' ? 'N/A' : user?.data.province}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Phone:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.phone === '' ? 'N/A' : user?.data.phone}</p>
+                </span>
+              </li>
+              <li>
+                <a class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full" href="applications">My Applications</a>
+              </li>
+            </ul>
+          </div>
+          <div class="profile-favs">
+            <div className="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
+              <p className="text-xl font-bold">Your Favorites</p>
+              <div className="-m-1 flex flex-wrap md:-m-2">
+                {favPets?.map((pet) => (
+                  <div className="flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2">
+                    <a href={`/petlistings/${pet.id}`} className="w-full block">
+                      <img
+                        alt={pet.name}
+                        className="block w-full h-64 object-cover object-center rounded-lg"
+                        src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : "../../../images/logo_ref.png"}
+                      />
+                    </a>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+      )
+    } else {
+      return (
+        <div class="profile-grid">
+          <div class="profile-img">
+              <div class="profile-container">
+                <img class="rounded-full w-full h-full" src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : "../../../images/logo_ref.png"} alt="../../../images/logo_ref.png" />
+              </div>
+              <a href="profile/edit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full">Edit Profile</a>
+          </div>
+          <div class="profile-desc">
+            <p class="font-semibold text-5xl break-all">Your Profile</p>
+            <hr class="line"></hr>
+            <ul class="profile-list">
+              <li>
+                <span class="font-bold">Email:</span>
+                <span class="text-gray-700">
+                  <a href="mailto: {user?.data.email}">{user?.data.email}</a>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Adress:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.address === '' ? 'N/A' : user?.data.address}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Postal Code:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.postal_code === '' ? 'N/A' : user?.data.postal_code}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">City:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.city === '' ? 'N/A' : user?.data.city}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Province:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.province === '' ? 'N/A' : user?.data.province}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Phone:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.phone === '' ? 'N/A' : user?.data.phone}</p>
+                </span>
+              </li>
+              <li>
+                <span class="font-bold">Mission Statement:</span>
+                <span class="text-gray-700">
+                  <p>{user?.data.description === '' ? 'N/A' : user?.data.description}</p>
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div class="profile-favs">
+            <div class="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
+              <div class="shelter-pet-list">
+                <p class="text-xl font-bold center-text mr-4">Listed Pets</p>
+                  <a href="petlistings/create">
+                    <button class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-1 px-4 rounded-full">
+                      +
+                    </button>
+                  </a>
+              </div>
+              <div className="-m-1 flex flex-wrap md:-m-2">
+                {shelterPets?.map((pet) => (
+                  <div className="flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2 flex flex-col items-center">
+                    <a href={`/petlistings/${pet.id}/edit`} className="w-full block">
+                      <img
+                        alt={pet.name}
+                        className="block w-full h-64 rounded-lg object-cover object-center"
+                        src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : "../../../images/logo_ref.png"}
+                      />
+                    </a>
+                    <p className="text-center">{pet.name}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )
+    }
+  }
+
+  return (
+    <div class="w-full h-full">
+      {user && renderProfile()}
     </div>
+
+
   )
 }
 

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -1,7 +1,107 @@
+import React, { useEffect, useState } from 'react'
+import { useAuth } from '../../context/AuthContext'
+import './Profile.css'
+import '../../styles/tailwind.css'
 
 function Profile() {
+  const { token, userId, role } = useAuth()
+  const [user, setUser] = useState(null)
+
+  useEffect(() => {
+    // Fetch user data
+    if (role === 'seeker') {
+      fetch(`${process.env.REACT_APP_API_URL}/api/seekers/${userId}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      }).then(res => res.json())
+        .then(data => setUser(data))
+        .catch(err => console.log(err))
+    } else {
+      fetch(`${process.env.REACT_APP_API_URL}/api/shelters/${userId}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      }).then(res => res.json())
+        .then(data => setUser(data))
+        .catch(err => console.log(err))
+    }
+  }, [token, userId, role])
+
   return (
-    <div>Profile</div>
+    <div class="profile-grid">
+      <div class="profile-img">
+          <div class="profile-container">
+            <img class="rounded-full w-full h-full" src={`${process.env.REACT_APP_API_URL}${user?.user_data.avatar}`} alt="profile" />
+          </div>
+          <a href="profile/edit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-full">Edit Profile</a>
+      </div>
+      <div class="profile-desc">
+        <p class="font-semibold text-5xl break-all">Your Profile</p>
+        <hr class="line"></hr>
+        <ul class="profile-list">
+          <li>
+            <span class="font-bold">Email:</span>
+            <span class="text-gray-700">
+              <a href="mailto: {user?.user_data.email}">{user?.user_data.email}</a>
+            </span>
+          </li>
+          <li>
+            <span class="font-bold">Adress:</span>
+            <span class="text-gray-700">
+              <p>{user?.user_data.address === '' ? 'N/A' : user?.user_data.address}</p>
+            </span>
+          </li>
+          <li>
+            <span class="font-bold">Postal Code:</span>
+            <span class="text-gray-700">
+              <p>{user?.user_data.postal_code === '' ? 'N/A' : user?.user_data.postal_code}</p>
+            </span>
+          </li>
+          <li>
+            <span class="font-bold">City:</span>
+            <span class="text-gray-700">
+              <p>{user?.user_data.city === '' ? 'N/A' : user?.user_data.city}</p>
+            </span>
+          </li>
+          <li>
+            <span class="font-bold">Province:</span>
+            <span class="text-gray-700">
+              <p>{user?.user_data.province === '' ? 'N/A' : user?.user_data.province}</p>
+            </span>
+          </li>
+          <li>
+            <span class="font-bold">Phone:</span>
+            <span class="text-gray-700">
+              <p>{user?.user_data.phone === '' ? 'N/A' : user?.user_data.phone}</p>
+            </span>
+          </li>
+          <li>
+            <a class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full" href="applications">My Applications</a>
+          </li>
+        </ul>
+      </div>
+      <div class="profile-favs">
+        <div class="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
+          <p class="text-xl font-bold">Your Favorites</p>
+          <div class="-m-1 flex flex-wrap md:-m-2">
+            {user?.fav_pets.map((pet) => (
+              <div class="flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2 flex justify-center items-center">
+                <a href={`/petlistings/${pet.id}`}>
+                  <img
+                  alt="gallery"
+                  class="block h-64 w-full rounded-lg object-cover object-center"
+                  src="TODO: Add image here"
+                  />
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -14,14 +14,20 @@ function Profile() {
 
   useEffect(() => {
     if (!token) return navigate('/login')
+    console.log(userId)
     // Fetch user data
-    fetch(`${process.env.REACT_APP_API_URL}/api/${role}s/${userId}`, { // TODO: Change to /api/seekers/${userId
+    fetch(`${process.env.REACT_APP_API_URL}/api/${role}s/${userId}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`
       }
     }).then(res => res.json())
-      .then(data => setUser(data))
+      .then(data => {
+        if (data.code === 'token_not_valid') {
+          navigate('/login')
+        } else {
+          setUser(data)
+        }})
       .catch(err => console.log(err))
     
     // Different fetches for different roles
@@ -31,6 +37,7 @@ function Profile() {
           const data = await getShelterPets()
           setShelterPets(data)
           const reviews = await getReviews()
+          console.log(reviews)
           setReviews(reviews)
         } else if (role === 'seeker') {
           const data = await getFavPets()
@@ -255,7 +262,7 @@ function Profile() {
                         <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
                       </svg>
                     ))}
-                    {user?.data.avg_rating} out of 5
+                    {user?.data.avg_rating.toFixed(2)} out of 5
                   </div>
                 )}
               </div>
@@ -349,9 +356,9 @@ function Profile() {
                       <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
                     </svg>
                   ))}
-                  <p class="ml-2">{review.rating} out of 5</p>
+                  <p class="ml-2">{review.rating.toFixed(2)} out of 5</p>
                 </div>
-                <div class="mt-2">{review.content}</div>
+                <div class="mt-2">{review.seeker}: {review.content}</div>
                 {review?.reply ? (
                   <p>Your response: {review?.reply.content}</p>
                 ) : (

--- a/frontend/src/pages/profile/ProfileEdit.jsx
+++ b/frontend/src/pages/profile/ProfileEdit.jsx
@@ -32,7 +32,9 @@ function ProfileEdit() {
     }
     formData.append('is_notif_comment', document.getElementById('comment-checkbox').checked)
     formData.append('is_notif_status', document.getElementById('status-checkbox').checked)
-    formData.append('is_notif_petlisting', document.getElementById('petlisting-checkbox').checked)
+    if (role === 'seeker') {
+      formData.append('is_notif_petlisting', document.getElementById('petlisting-checkbox').checked)
+    }
     fetch(`${process.env.REACT_APP_API_URL}/api/${role}s/${userId}`, {
       method: 'PUT',
       headers: {
@@ -44,67 +46,140 @@ function ProfileEdit() {
       .catch(err => console.log(err))
   }
 
+  const renderProfile = () => {
+    if (role === 'seeker') {
+      return (
+        <div class="profile-grid">
+          <div class="profile-img">
+            <div class="profile-container">
+              <img class="rounded-full w-full h-full" src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : "../../../images/logo_ref.png"} alt="../../../images/logo_ref.png" />
+              </div>
+            <input type="file" id="profile-image" name="profile-image" accept="image/*"
+              onChange={(e) => setAvatar(e.target.files[0])}
+            />
+          </div>
+          <div class="profile-desc">
+            <p class="font-semibold text-5xl break-all">Your Profile</p>
+            <hr class="line"></hr>
+            <form class="profile-form" id="profile-form" onSubmit={handleSubmit}>
+              <div class="mb-4">
+                <label for="email" class="font-bold">Email:</label>
+                <input type="email" id="email" name="email" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.email} required/>
+              </div>
+              <div class="mb-4">
+                <label for="address" class="font-bold">Address:</label>
+                <input type="text" id="address" name="address" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.address}/>
+              </div>
+              <div class="mb-4">
+                <label for="postal" class="font-bold">Postal Code:</label>
+                <input type="text" id="postal" name="postal" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.postal_code}/>
+              </div>
+              <div class="mb-4">
+                <label for="city" class="font-bold">City:</label>
+                <input type="text" id="city" name="city" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.city}/>
+              </div>
+              <div class="mb-4">
+                <label for="province" class="font-bold">Province:</label>
+                <input type="text" id="province" name="province" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.province}/>
+              </div>
+              <div class="mb-4">
+                <label for="phone" class="font-bold">Phone:</label>
+                <input type="tel" id="phone" name="phone" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.phone}/>
+              </div>
+              <div class="flex items-center mb-4">
+                <input id="comment-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  defaultChecked={user?.data.is_notif_comment}
+                />
+                <label for="comment-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for comments</label>
+              </div>
+              <div class="flex items-center mb-4">
+                <input id="status-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  defaultChecked={user?.data.is_notif_status}
+                />
+                <label for="status-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for status change</label>
+              </div>
+              <div class="flex items-center mb-4">
+                <input id="petlisting-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  defaultChecked={user?.data.is_notif_petlisting}
+                />
+                <label for="petlisting-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for petlistings</label>
+              </div>
+              <div class="mb-4">
+              <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full">Update Profile</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )
+    } else {
+      return (
+        <div class="profile-grid">
+          <div class="profile-img">
+            <div class="profile-container">
+              <img class="rounded-full w-full h-full" src={user?.data.avatar? `${process.env.REACT_APP_API_URL}${user?.data.avatar}` : "../../../images/logo_ref.png"} alt="../../../images/logo_ref.png" />
+              </div>
+            <input type="file" id="profile-image" name="profile-image" accept="image/*"
+              onChange={(e) => setAvatar(e.target.files[0])}
+            />
+          </div>
+          <div class="profile-desc">
+            <p class="font-semibold text-5xl break-all">Your Profile</p>
+            <hr class="line"></hr>
+            <form class="profile-form" id="profile-form" onSubmit={handleSubmit}>
+              <div class="mb-4">
+                <label for="email" class="font-bold">Email:</label>
+                <input type="email" id="email" name="email" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.email} required/>
+              </div>
+              <div class="mb-4">
+                <label for="address" class="font-bold">Address:</label>
+                <input type="text" id="address" name="address" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.address}/>
+              </div>
+              <div class="mb-4">
+                <label for="postal" class="font-bold">Postal Code:</label>
+                <input type="text" id="postal" name="postal" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.postal_code}/>
+              </div>
+              <div class="mb-4">
+                <label for="city" class="font-bold">City:</label>
+                <input type="text" id="city" name="city" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.city}/>
+              </div>
+              <div class="mb-4">
+                <label for="province" class="font-bold">Province:</label>
+                <input type="text" id="province" name="province" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.province}/>
+              </div>
+              <div class="mb-4">
+                <label for="phone" class="font-bold">Phone:</label>
+                <input type="tel" id="phone" name="phone" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.phone}/>
+              </div>
+              <div class="mb-4">
+                <label for="description" class="font-bold">Mission Statement:</label>
+                <input type="tel" id="description" name="description" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.data.description}/>
+              </div>
+              <div class="flex items-center mb-4">
+                <input id="comment-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  defaultChecked={user?.data.is_notif_comment}
+                />
+                <label for="comment-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for comments</label>
+              </div>
+              <div class="flex items-center mb-4">
+                <input id="status-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                  defaultChecked={user?.data.is_notif_status}
+                />
+                <label for="status-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for status change</label>
+              </div>
+              <div class="mb-4">
+              <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full">Update Profile</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )
+    }
+  }
+
+
   return (
-    <div class="profile-grid">
-      <div class="profile-img">
-          <div class="profile-container">
-            <img class="rounded-full w-full h-full" src={`${process.env.REACT_APP_API_URL}${user?.user_data.avatar }`} alt="profile" />
-          </div>
-          <input type="file" id="profile-image" name="profile-image" accept="image/*"
-            onChange={(e) => setAvatar(e.target.files[0])}
-          />
-      </div>
-      <div class="profile-desc">
-        <p class="font-semibold text-5xl break-all">Your Profile</p>
-        <hr class="line"></hr>
-        <form class="profile-form" id="profile-form" onSubmit={handleSubmit}>
-          <div class="mb-4">
-            <label for="email" class="font-bold">Email:</label>
-            <input type="email" id="email" name="email" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.email} required/>
-          </div>
-          <div class="mb-4">
-            <label for="address" class="font-bold">Address:</label>
-            <input type="text" id="address" name="address" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.address}/>
-          </div>
-          <div class="mb-4">
-            <label for="postal" class="font-bold">Postal Code:</label>
-            <input type="text" id="postal" name="postal" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.postal_code}/>
-          </div>
-          <div class="mb-4">
-            <label for="city" class="font-bold">City:</label>
-            <input type="text" id="city" name="city" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.city}/>
-          </div>
-          <div class="mb-4">
-            <label for="province" class="font-bold">Province:</label>
-            <input type="text" id="province" name="province" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.province}/>
-          </div>
-          <div class="mb-4">
-            <label for="phone" class="font-bold">Phone:</label>
-            <input type="tel" id="phone" name="phone" class="w-full px-3 py-2 border rounded-lg" defaultValue="123-456-7890"/>
-          </div>
-          <div class="flex items-center mb-4">
-            <input id="comment-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-              defaultChecked={user?.user_data.is_notif_comment}
-            />
-            <label for="comment-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for comments</label>
-          </div>
-          <div class="flex items-center mb-4">
-            <input id="status-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-              defaultChecked={user?.user_data.is_notif_status}
-            />
-            <label for="status-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for status change</label>
-          </div>
-          <div class="flex items-center mb-4">
-            <input id="petlisting-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-              defaultChecked={user?.user_data.is_notif_petlisting}
-            />
-            <label for="petlisting-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for petlistings</label>
-          </div>
-          <div class="mb-4">
-          <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full">Update Profile</button>
-          </div>
-        </form>
-      </div>
+    <div class="w-full h-full">
+      {renderProfile()}
     </div>
   )
 }

--- a/frontend/src/pages/profile/ProfileEdit.jsx
+++ b/frontend/src/pages/profile/ProfileEdit.jsx
@@ -1,7 +1,111 @@
+import React, { useEffect, useState } from 'react'
+import { useAuth } from '../../context/AuthContext'
+import './Profile.css'
+import '../../styles/tailwind.css'
+import { useNavigate } from 'react-router-dom'
 
 function ProfileEdit() {
+  const { token, userId, role } = useAuth()
+  const [user, setUser] = useState(null)
+  const [avatar, setAvatar] = useState(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    // Fetch user data
+    fetch(`${process.env.REACT_APP_API_URL}/api/${role}s/${userId}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }).then(res => res.json())
+      .then(data => {
+        setUser(data)
+      })
+      .catch(err => console.log(err))
+  }, [token, userId, role])
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    const formData = new FormData(e.target)
+    if (avatar) {
+      formData.append('avatar', avatar)
+    }
+    formData.append('is_notif_comment', document.getElementById('comment-checkbox').checked)
+    formData.append('is_notif_status', document.getElementById('status-checkbox').checked)
+    formData.append('is_notif_petlisting', document.getElementById('petlisting-checkbox').checked)
+    fetch(`${process.env.REACT_APP_API_URL}/api/${role}s/${userId}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: formData
+    }).then(res => res.json())
+      .then(navigate('/profile'))
+      .catch(err => console.log(err))
+  }
+
   return (
-    <div>Update Profile</div>
+    <div class="profile-grid">
+      <div class="profile-img">
+          <div class="profile-container">
+            <img class="rounded-full w-full h-full" src={`${process.env.REACT_APP_API_URL}${user?.user_data.avatar }`} alt="profile" />
+          </div>
+          <input type="file" id="profile-image" name="profile-image" accept="image/*"
+            onChange={(e) => setAvatar(e.target.files[0])}
+          />
+      </div>
+      <div class="profile-desc">
+        <p class="font-semibold text-5xl break-all">Your Profile</p>
+        <hr class="line"></hr>
+        <form class="profile-form" id="profile-form" onSubmit={handleSubmit}>
+          <div class="mb-4">
+            <label for="email" class="font-bold">Email:</label>
+            <input type="email" id="email" name="email" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.email} required/>
+          </div>
+          <div class="mb-4">
+            <label for="address" class="font-bold">Address:</label>
+            <input type="text" id="address" name="address" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.address}/>
+          </div>
+          <div class="mb-4">
+            <label for="postal" class="font-bold">Postal Code:</label>
+            <input type="text" id="postal" name="postal" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.postal_code}/>
+          </div>
+          <div class="mb-4">
+            <label for="city" class="font-bold">City:</label>
+            <input type="text" id="city" name="city" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.city}/>
+          </div>
+          <div class="mb-4">
+            <label for="province" class="font-bold">Province:</label>
+            <input type="text" id="province" name="province" class="w-full px-3 py-2 border rounded-lg" defaultValue={user?.user_data.province}/>
+          </div>
+          <div class="mb-4">
+            <label for="phone" class="font-bold">Phone:</label>
+            <input type="tel" id="phone" name="phone" class="w-full px-3 py-2 border rounded-lg" defaultValue="123-456-7890"/>
+          </div>
+          <div class="flex items-center mb-4">
+            <input id="comment-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+              defaultChecked={user?.user_data.is_notif_comment}
+            />
+            <label for="comment-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for comments</label>
+          </div>
+          <div class="flex items-center mb-4">
+            <input id="status-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+              defaultChecked={user?.user_data.is_notif_status}
+            />
+            <label for="status-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for status change</label>
+          </div>
+          <div class="flex items-center mb-4">
+            <input id="petlisting-checkbox" type="checkbox" value="" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+              defaultChecked={user?.user_data.is_notif_petlisting}
+            />
+            <label for="petlisting-checkbox" class="ms-2 text-sm font-medium">Recieve Notifications for petlistings</label>
+          </div>
+          <div class="mb-4">
+          <button type="submit" class="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full">Update Profile</button>
+          </div>
+        </form>
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/pages/profile/ProfileOther.jsx
+++ b/frontend/src/pages/profile/ProfileOther.jsx
@@ -1,0 +1,475 @@
+import React, { useEffect, useState } from 'react'
+import { useAuth } from '../../context/AuthContext'
+import './Profile.css'
+import '../../styles/tailwind.css'
+import { useNavigate } from 'react-router-dom'
+
+function ProfileOther() {
+    const { token, userId, role } = useAuth()
+    const [seeker, setSeeker] = useState(null)
+    const [shelter, setShelter] = useState(null)
+    const [shelterPets, setShelterPets] = useState(null)
+    const [shelterReviews, setShelterReviews] = useState(null)
+    // 1 = seeker->shelter, 2 = shelter->seeker, 3 = shelter->shelter
+    const [state, setState] = useState(0)
+    const navigate = useNavigate()
+    const url = window.location.href
+    const urlSplit = url.split('/')
+    const otherUserId = urlSplit[urlSplit.length - 1]
+
+    useEffect(() => {
+        if (otherUserId === userId) {
+            return navigate('/profile')
+        }
+
+        try {
+            fetch(`${process.env.REACT_APP_API_URL}/api/shelters/${otherUserId}`, {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            })
+                .then((res) => {
+                    if (res.status === 403 || res.status === 404) {
+                        fetch(`${process.env.REACT_APP_API_URL}/api/seekers/${otherUserId}`, {
+                            headers: {
+                                Authorization: `Bearer ${token}`,
+                            },
+                        })
+                            .then((res) => {
+                                if (res.status === 403 || res.status === 404) {
+                                    navigate('/profile')
+                                } else {
+                                    return res.json()
+                                }
+                            })
+                            .then((data) => {
+                                setSeeker(data)
+                                setState(2)
+                            })
+                            .catch((err) => {
+                                console.log(err)
+                            })
+                        } else {
+                            return res.json()
+                        }
+                    })
+                    .then((data) => {
+                        setShelter(data)
+                        if (role === 'seeker') {
+                            setState(1)
+                        } else {
+                            setState(3)
+                        }
+                    })
+                    .catch((err) => {
+                        console.log(err)
+                    })
+        } catch (err) {
+            console.log(err)
+        }
+    }, [token, userId, role, navigate])
+
+    useEffect(() => {
+        const getShelterPets = async () => {
+            var nextPage = `${process.env.REACT_APP_API_URL}/api/petlistings/shelter/${shelter?.data.email}`
+            const allResults = []
+            try {
+                while (nextPage) {
+                    const res = await fetch(nextPage, {
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                        },
+                    })
+                    const data = await res.json()
+                    allResults.push(...data.results.data)
+                    nextPage = data.next
+                }
+                console.log("all", allResults)
+                setShelterPets(allResults)
+            } catch (err) {
+                console.log(err)
+            }
+        }
+
+        const getShelterReviews = async () => {
+            console.log(shelter?.data)
+            var nextPage = `${process.env.REACT_APP_API_URL}/api/comments/shelter/${otherUserId}`
+            const allResults = []
+            var pageNum = 1
+            try {
+                while (nextPage) {
+                    const res = await fetch(nextPage, {
+                        method: 'GET',
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                        },
+                    })
+                    const data = await res.json()
+                    allResults.push(...data.data)
+                    if (data.page.has_next) {
+                        nextPage = `${process.env.REACT_APP_API_URL}/api/comments/shelter/${otherUserId}?page=${pageNum + 1}`
+                        pageNum += 1
+                    } else {
+                        break
+                    }
+                }
+                console.log("allreviews", allResults)
+                setShelterReviews(allResults)
+            } catch (err) {
+                console.log(err)
+            }
+        }
+
+        if (shelter?.data.email) {
+            getShelterPets()
+            getShelterReviews()
+        }
+    }, [shelter?.data.email, token, otherUserId, shelter?.data])
+
+    
+
+    const renderProfile = () => {
+        // 3 cases: seeker->shelter, shelter->seeker, shelter->shelter
+        switch (state) {
+            case 1:
+                return renderSeekerShelter()
+            case 2:
+                return renderShelterSeeker()
+            case 3:
+                return renderShelterShelter()
+            default:
+                navigate('/profile')
+        }
+    }
+
+    const renderSeekerShelter = () => {
+        return (
+        <div>
+            <div class='profile-grid'>
+            <div class='profile-img'>
+                <div class='profile-container'>
+                  <img class='rounded-full w-full h-full' src={shelter?.data.avatar? `${process.env.REACT_APP_API_URL}${shelter?.data.avatar}` : '../../../images/logo_ref.png'} alt='../../../images/logo_ref.png' />
+                </div>
+            </div>
+            <div class='profile-desc'>
+              <p class='font-semibold text-5xl break-all'>Shelter Profile</p>
+              <div class="flex items-center">
+                {shelter?.data.avg_rating === 0 ? (
+                    <span>No Rating</span>
+                ) : (
+                    <div class="flex items-center">
+                    {Array.from({ length: shelter?.data.avg_rating }, (_, index) => (
+                        <svg
+                        key={index}
+                        class="w-4 h-4 text-yellow-300 me-1"
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="currentColor"
+                        viewBox="0 0 22 20"
+                        >
+                        <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
+                        </svg>
+                    ))}
+                    {shelter?.data.avg_rating} out of 5
+                    </div>
+                )}
+                </div>
+              <hr class='line'></hr>
+              <ul class='profile-list'>
+                <li>
+                  <span class='font-bold'>Email:</span>
+                  <span class='text-gray-700'>
+                    <a href={`mailto:${shelter?.data.email}`}>{shelter?.data.email}</a>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Adress:</span>
+                  <span class='text-gray-700'>
+                    <p>{shelter?.data.address === '' ? 'N/A' : shelter?.data.address}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Postal Code:</span>
+                  <span class='text-gray-700'>
+                    <p>{shelter?.data.postal_code === '' ? 'N/A' : shelter?.data.postal_code}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>City:</span>
+                  <span class='text-gray-700'>
+                    <p>{shelter?.data.city === '' ? 'N/A' : shelter?.data.city}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Province:</span>
+                  <span class='text-gray-700'>
+                    <p>{shelter?.data.province === '' ? 'N/A' : shelter?.data.province}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Phone:</span>
+                  <span class='text-gray-700'>
+                    <p>{shelter?.data.phone === '' ? 'N/A' : shelter?.data.phone}</p>
+                  </span>
+                </li>
+                <li>
+                  <span class='font-bold'>Mission Statement:</span>
+                  <span class='text-gray-700'>
+                    <p>{shelter?.data.description === '' ? 'N/A' : shelter?.data.description}</p>
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div class='profile-favs'>
+              <div class='container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4'>
+                <div class='shelter-pet-list'>
+                  <p class='text-xl font-bold center-text mr-4'>Listed Pets</p>
+                </div>
+                <div className='-m-1 flex flex-wrap md:-m-2'>
+                  {shelterPets?.map((pet) => (
+                    <div className='flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2 flex flex-col items-center'>
+                      <a href={`/petlistings/${pet.id}`} className='w-full block'>
+                        <img
+                          alt={pet.name}
+                          className='block w-full h-64 rounded-lg object-cover object-center'
+                          src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : '../../../images/logo_ref.png'}
+                        />
+                      </a>
+                      <p className='text-center'>{pet.name}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
+                <p class="text-xl font-bold center-text mr-4">Shelter Reviews</p>
+                {shelterReviews?.map((review) => (
+                <div class="review-box mx-auto flex items-center flex-col rounded-lg bg-white p-6 shadow-[0_2px_15px_-3px_rgba(0,0,0,0.07),0_10px_20px_-2px_rgba(0,0,0,0.04)] dark:bg-neutral-700">
+                    <div class="flex items-center">
+                    {Array.from({ length: review.rating }, (_, index) => (
+                        <svg
+                        key={index}
+                        class="w-4 h-4 text-yellow-300 me-1"
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="currentColor"
+                        viewBox="0 0 22 20"
+                        >
+                        <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
+                        </svg>
+                    ))}
+                    <p class="ml-2">{review.rating} out of 5</p>
+                    </div>
+                    <div class="mt-2">{review.content}</div>
+                    {review?.reply ? (
+                    <p>Shelter's response: {review?.reply.content}</p>
+                    ) : (
+                    <div>
+                    </div>
+                    )}
+                </div>
+                ))}
+          </div>
+        </div>
+        )
+    }
+
+    const renderShelterSeeker = () => {
+        return (
+            <div class='profile-grid'>
+            <div class='profile-img'>
+                <div class='profile-container'>
+                    <img class='rounded-full w-full h-full' src={seeker?.data.avatar? `${process.env.REACT_APP_API_URL}${seeker?.data.avatar}` : '../../../images/logo_ref.png'} alt='../../../images/logo_ref.png' />
+                </div>
+            </div>
+            <div class='profile-desc'>
+                <p class='font-semibold text-5xl break-all'>Seeker Profile</p>
+                <hr class='line'></hr>
+                <ul class='profile-list'>
+                <li>
+                    <span class='font-bold'>Email:</span>
+                    <span class='text-gray-700'>
+                    <a href={`mailto:${seeker?.data.email}`}>{seeker?.data.email}</a>
+                    </span>
+                </li>
+                <li>
+                    <span class='font-bold'>Adress:</span>
+                    <span class='text-gray-700'>
+                    <p>{seeker?.data.address === '' ? 'N/A' : seeker?.data.address}</p>
+                    </span>
+                </li>
+                <li>
+                    <span class='font-bold'>Postal Code:</span>
+                    <span class='text-gray-700'>
+                    <p>{seeker?.data.postal_code === '' ? 'N/A' : seeker?.data.postal_code}</p>
+                    </span>
+                </li>
+                <li>
+                    <span class='font-bold'>City:</span>
+                    <span class='text-gray-700'>
+                    <p>{seeker?.data.city === '' ? 'N/A' : seeker?.data.city}</p>
+                    </span>
+                </li>
+                <li>
+                    <span class='font-bold'>Province:</span>
+                    <span class='text-gray-700'>
+                    <p>{seeker?.data.province === '' ? 'N/A' : seeker?.data.province}</p>
+                    </span>
+                </li>
+                <li>
+                    <span class='font-bold'>Phone:</span>
+                    <span class='text-gray-700'>
+                    <p>{seeker?.data.phone === '' ? 'N/A' : seeker?.data.phone}</p>
+                    </span>
+                </li>
+                <li>
+                    <a class='bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded-full' href='applications'>Seeker Applications</a>
+                </li>
+                </ul>
+            </div>
+        </div>
+        )
+    }
+
+    const renderShelterShelter = () => {
+        return (
+            <div>
+                <div class='profile-grid'>
+                <div class='profile-img'>
+                    <div class='profile-container'>
+                    <img class='rounded-full w-full h-full' src={shelter?.data.avatar? `${process.env.REACT_APP_API_URL}${shelter?.data.avatar}` : '../../../images/logo_ref.png'} alt='../../../images/logo_ref.png' />
+                    </div>
+                </div>
+                <div class='profile-desc'>
+                <p class='font-semibold text-5xl break-all'>Shelter Profile</p>
+                <div class="flex items-center">
+                    {shelter?.data.avg_rating === 0 ? (
+                        <span>No Rating</span>
+                    ) : (
+                        <div class="flex items-center">
+                        {Array.from({ length: shelter?.data.avg_rating }, (_, index) => (
+                            <svg
+                            key={index}
+                            class="w-4 h-4 text-yellow-300 me-1"
+                            aria-hidden="true"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="currentColor"
+                            viewBox="0 0 22 20"
+                            >
+                            <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
+                            </svg>
+                        ))}
+                        {shelter?.data.avg_rating} out of 5
+                        </div>
+                    )}
+                    </div>
+                <hr class='line'></hr>
+                <ul class='profile-list'>
+                    <li>
+                    <span class='font-bold'>Email:</span>
+                    <span class='text-gray-700'>
+                        <a href={`mailto:${shelter?.data.email}`}>{shelter?.data.email}</a>
+                    </span>
+                    </li>
+                    <li>
+                    <span class='font-bold'>Adress:</span>
+                    <span class='text-gray-700'>
+                        <p>{shelter?.data.address === '' ? 'N/A' : shelter?.data.address}</p>
+                    </span>
+                    </li>
+                    <li>
+                    <span class='font-bold'>Postal Code:</span>
+                    <span class='text-gray-700'>
+                        <p>{shelter?.data.postal_code === '' ? 'N/A' : shelter?.data.postal_code}</p>
+                    </span>
+                    </li>
+                    <li>
+                    <span class='font-bold'>City:</span>
+                    <span class='text-gray-700'>
+                        <p>{shelter?.data.city === '' ? 'N/A' : shelter?.data.city}</p>
+                    </span>
+                    </li>
+                    <li>
+                    <span class='font-bold'>Province:</span>
+                    <span class='text-gray-700'>
+                        <p>{shelter?.data.province === '' ? 'N/A' : shelter?.data.province}</p>
+                    </span>
+                    </li>
+                    <li>
+                    <span class='font-bold'>Phone:</span>
+                    <span class='text-gray-700'>
+                        <p>{shelter?.data.phone === '' ? 'N/A' : shelter?.data.phone}</p>
+                    </span>
+                    </li>
+                    <li>
+                    <span class='font-bold'>Mission Statement:</span>
+                    <span class='text-gray-700'>
+                        <p>{shelter?.data.description === '' ? 'N/A' : shelter?.data.description}</p>
+                    </span>
+                    </li>
+                </ul>
+                </div>
+                <div class='profile-favs'>
+                <div class='container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4'>
+                    <div class='shelter-pet-list'>
+                    <p class='text-xl font-bold center-text mr-4'>Listed Pets</p>
+                    </div>
+                    <div className='-m-1 flex flex-wrap md:-m-2'>
+                    {shelterPets?.map((pet) => (
+                        <div className='flex w-full md:w-1/2 lg:w-1/3 p-1 md:p-2 flex flex-col items-center'>
+                        <a href={`/petlistings/${pet.id}`} className='w-full block'>
+                            <img
+                            alt={pet.name}
+                            className='block w-full h-64 rounded-lg object-cover object-center'
+                            src={pet.photos[0] ? `${process.env.REACT_APP_API_URL}${pet.photos[0].url}` : '../../../images/logo_ref.png'}
+                            />
+                        </a>
+                        <p className='text-center'>{pet.name}</p>
+                        </div>
+                    ))}
+                    </div>
+                </div>
+                </div>
+            </div>
+            <div class="container mx-auto mb-4 px-5 py-2 lg:px-32 lg:pt-12 space-y-4">
+                <p class="text-xl font-bold center-text mr-4">Shelter Reviews</p>
+                {shelterReviews?.map((review) => (
+                <div class="review-box mx-auto flex items-center flex-col rounded-lg bg-white p-6 shadow-[0_2px_15px_-3px_rgba(0,0,0,0.07),0_10px_20px_-2px_rgba(0,0,0,0.04)] dark:bg-neutral-700">
+                    <div class="flex items-center">
+                    {Array.from({ length: review.rating }, (_, index) => (
+                        <svg
+                        key={index}
+                        class="w-4 h-4 text-yellow-300 me-1"
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="currentColor"
+                        viewBox="0 0 22 20"
+                        >
+                        <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
+                        </svg>
+                    ))}
+                    <p class="ml-2">{review.rating} out of 5</p>
+                    </div>
+                    <div class="mt-2">{review.content}</div>
+                    {review?.reply ? (
+                    <p>Shelter's response: {review?.reply.content}</p>
+                    ) : (
+                    <div>
+                    </div>
+                    )}
+                </div>
+                ))}
+          </div>
+        </div>
+        )
+    }
+
+    return (
+        <div class='w-full h-full'>
+            {renderProfile()}
+        </div>
+    )
+}
+
+export default ProfileOther

--- a/frontend/src/pages/profile/ProfileOther.jsx
+++ b/frontend/src/pages/profile/ProfileOther.jsx
@@ -286,11 +286,11 @@ function ProfileOther() {
                         <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
                         </svg>
                     ))}
-                    <p class="ml-2">{review.rating.toFixed(2)} out of 5</p>
+                    <p class="mt-2 text-white">{review.rating.toFixed(2)} out of 5</p>
                     </div>
-                    <div class="mt-2">{review.seeker}: {review.content}</div>
+                    <div class="mt-2 text-white">{review.seeker}: {review.content}</div>
                     {review?.reply ? (
-                    <p>Shelter's response: {review?.reply.content}</p>
+                    <p class="mt-2 text-white">Shelter's response: {review?.reply.content}</p>
                     ) : (
                     <div>
                     </div>
@@ -497,11 +497,11 @@ function ProfileOther() {
                         <path d="M20.924 7.625a1.523 1.523 0 0 0-1.238-1.044l-5.051-.734-2.259-4.577a1.534 1.534 0 0 0-2.752 0L7.365 5.847l-5.051.734A1.535 1.535 0 0 0 1.463 9.2l3.656 3.563-.863 5.031a1.532 1.532 0 0 0 2.226 1.616L11 17.033l4.518 2.375a1.534 1.534 0 0 0 2.226-1.617l-.863-5.03L20.537 9.2a1.523 1.523 0 0 0 .387-1.575Z"/>
                         </svg>
                     ))}
-                    <p class="ml-2">{review.rating.toFixed(2)} out of 5</p>
+                    <p class="mt-2 text-white">{review.rating.toFixed(2)} out of 5</p>
                     </div>
-                    <div class="mt-2">{review.seeker}: {review.content}</div>
+                    <div class="mt-2 text-white">{review.seeker}: {review.content}</div>
                     {review?.reply ? (
-                    <p>Shelter's response: {review?.reply.content}</p>
+                    <p class="mt-2 text-white">Shelter's response: {review?.reply.content}</p>
                     ) : (
                     <div>
                     </div>

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+


### PR DESCRIPTION
Implementation of Profile
- User can view their own profile and edit
<img width="1081" alt="image" src="https://github.com/lujorryn/PetPal-G0346/assets/86802756/f5c7df01-45c2-4a1b-84ab-ae68af6cb95a">
<img width="1085" alt="image" src="https://github.com/lujorryn/PetPal-G0346/assets/86802756/d9be186a-5005-4b33-976c-059a55fc9c2e">
Note here since the petlisting doesn't include the pet images, updating this with Postman will reflect the changes

- Seekers have their list of favorited pets, shelters have their list of petlistings, each redirects to the pet
- Shelters have reviews, only seekers can write reviews for shelters once, shelters can reply to the review.
<img width="968" alt="image" src="https://github.com/lujorryn/PetPal-G0346/assets/86802756/d77ebbe8-0c31-4e21-a645-da23d769f519">

- Seekers can see all shelters by going to /profile/<shelter_id>, if they go to a seeker id, it will return to their own profile. Shelters can only see seeker's profiles if they have a common application. The ability to view other profiles are as follows: any seeker-> any shelter, any shelter -> any shelter, shelter -> seeker if they have common application.

- I have decided not to implement the shelter component as profile is something that seekers and shelters both have in common, only differing slightly in their implementation.
- Added tailwind configs so tailwind CSS will work
- Bug fixes for some backend logic and added extra features that are beneficial, such as average rating for a shelter, checking if a user already reviewed a shelter, and increase some paginated page size.